### PR TITLE
Fix grammar

### DIFF
--- a/ruby/rspec.md
+++ b/ruby/rspec.md
@@ -1,2 +1,2 @@
 # File name
-Every spec file must ends with `_spec.rb`.
+Every spec file has to end with `_spec.rb`.


### PR DESCRIPTION
"Must ends" is wrong. "Must end" is grammatically correct. However, in this context "has to end with" is better, because it concerns external obligation (in this case - convention).

see: https://learnenglishteens.britishcouncil.org/grammar-vocabulary/grammar-videos/have-must-and-should-obligation-and-advice
